### PR TITLE
タスク一覧にソート機能を追加(ransack) #9

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ class TasksController < ApplicationController
   def index
     # ransackによる検索によるタスクの取得
     @q = current_user.tasks.ransack(params[:q])
-    @tasks = @q.result(distinct: true).recent
+    @tasks = @q.result(distinct: true)
   end
 
   def show

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -18,8 +18,8 @@ h1 タスク一覧
 table.table.table-hover
   thead.thead-default
     tr
-      th= Task.human_attribute_name(:name)
-      th= Task.human_attribute_name(:created_at)
+      th= sort_link(@q, :name)
+      th= sort_link(@q, :created_at)
     tbody
       - @tasks.each do |task|
         tr


### PR DESCRIPTION
why
ユーザ操作性の向上のため

what
ransack の機能にて昇順、降順ソート機能を 名称、登録日時に追加